### PR TITLE
Fixed bug with command line input

### DIFF
--- a/StringCalculator/Program.cs
+++ b/StringCalculator/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace StringCalculator
 {
@@ -10,13 +11,38 @@ namespace StringCalculator
             string enteredString = Console.ReadLine();
 
             Console.WriteLine($"\nCalling Add method with input string: {enteredString}\n");
+
             Calculator calc = new Calculator();
+            string filteredString = FilterAdditionalBackslash(enteredString);
+            
+            try
+            {
+                int sum = calc.Add(filteredString);
+                Console.WriteLine($"The sum is: {sum}\n");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Sum could not be calculated.  Please check your input is valid\n");
+                Console.WriteLine(ex.Message);
+                Console.WriteLine(ex.StackTrace);
+            }            
 
-            int sum = calc.Add(enteredString);
-            Console.WriteLine($"The sum is: {sum}\n");
-
-            Console.WriteLine("Press Enter key to exit");
+            Console.WriteLine("\nPress Enter key to exit");
             Console.ReadLine();
         }
+
+        /// <summary>
+        /// .Net is adding an additional escape when taking input through Console.Readline that has escaped characters.  
+        /// It also removes this extra escape character when displaying back to the user through Console.Writeline.
+        /// We need to filter out the additional escaped backslash to support taking newline as part of the string as in the examples of the assignment
+        /// </summary>
+        /// <param name="enteredString"></param>
+        /// <returns>The strings like "\\n" are replaced by "\n"</returns>
+        private static string FilterAdditionalBackslash(string enteredString)
+        {
+            return Regex.Unescape(enteredString);
+        }
+
+
     }
 }


### PR DESCRIPTION
Bug was found where running from command line with \n as a delimiter was failing due to additonal escaped backslash added by Console.Readline.  Additional exception handling was added to provide user more feedback on what went wrong.