### PR TITLE
Added support for a single character custom delimiter for requirement 4

### DIFF
--- a/StringCalculator/Calculator.cs
+++ b/StringCalculator/Calculator.cs
@@ -23,8 +23,18 @@ namespace StringCalculator
             else
             {
                 int sum = 0;
-                string[] delimiters = new string[] { ",", "\n" };
-                string[] numbers = numberString.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+                int startOfNumberString = 0;
+                string customDelimiter = GetCustomDelimiter(numberString);
+                List<string> delimiterList = new List<string>();
+                delimiterList.Add(",");
+                delimiterList.Add("\n");
+                if (customDelimiter != null)
+                {
+                    delimiterList.Add(customDelimiter);
+                    startOfNumberString = numberString.IndexOf("\n") + 1;  //used to remove the custom delimiter portion of string
+                }
+
+                string[] numbers = numberString.Substring(startOfNumberString).Split(delimiterList.ToArray(), StringSplitOptions.RemoveEmptyEntries);
 
                 foreach (var number in numbers)
                 {
@@ -33,6 +43,21 @@ namespace StringCalculator
 
                 return sum;
             }
+        }
+
+        public string GetCustomDelimiter(string numberString)
+        {
+            int endDelimiterMarker = 0;
+
+            if (numberString.Length >= 2 && numberString.Substring(0,2) == "//")
+            {
+                endDelimiterMarker = numberString.IndexOf("\n");
+                if (endDelimiterMarker != -1)
+                {
+                    return numberString.Substring(2, endDelimiterMarker - 2);
+                }
+            }
+            return null;
         }
     }
 }

--- a/StringCalculatorTests/CalculatorUnitTest.cs
+++ b/StringCalculatorTests/CalculatorUnitTest.cs
@@ -37,7 +37,7 @@ namespace StringCalculatorTests
         /// </summary>
         [Theory]
         [InlineData("", 0)]
-        [InlineData("1", 1)]
+        [InlineData("99", 99)]
         [InlineData("1,2", 3)]
         [InlineData("1,2,3", 6)]
         [InlineData("1,2,3,4", 10)]
@@ -66,6 +66,39 @@ namespace StringCalculatorTests
         {
             int sum = calc.Add(numberString);
             Assert.Equal(expected, sum);
+        }
+
+        /// <summary>
+        /// 4.	Support user providing there own delimiters
+        ///   1.	to change a delimiter, the beginning of the string will contain a separate line that looks like this: 
+        ///   2.	“//[delimiter]\n[numbers…]” for example “//;\n1;2” should return three where the default delimiter is ‘;’ .
+        ///   3.	the first line is optional.all existing scenarios should still be supported
+        /// </summary>
+        [Theory]
+        [InlineData("//;\n1;2", 3)]
+        [InlineData("//;\n1,2\n3;4", 10)]
+        [InlineData("//*\n1\n2*3", 6)]
+        [InlineData("//&\n1\n2&3,4\n5", 15)]
+        public void TestFunctionality4(string numberString, int expected)
+        {
+            int sum = calc.Add(numberString);
+            Assert.Equal(expected, sum);
+        }
+
+        /// <summary>
+        /// Tests retrieval of custom delimiters in requirement 4
+        /// returns null if no custom delimiter is found, otherwise should return one delimiter
+        /// </summary>
+        /// <param name="numberString"></param>
+        /// <param name="expected"></param>
+        [Theory]
+        [InlineData("//;\n1;2", ";")]
+        [InlineData("//;\n1;2\n4", ";")]
+        [InlineData("1,2\n4", null)]  
+        public void TestDelimiter(string numberString, string expected)
+        {
+            string delimiter = calc.GetCustomDelimiter(numberString);
+            Assert.Equal(expected, delimiter);
         }
     }
 }


### PR DESCRIPTION
Added new mehod to parse out custom delimiater along with corresponding unit test.
4.	Support different delimiters
1.	to change a delimiter, the beginning of the string will contain a separate line that looks like this:
2.	“//[delimiter]\n[numbers…]” for example “//;\n1;2” should return three where the default delimiter is ‘;’ .
3.	the first line is optional. all existing scenarios should still be supported