### PR TITLE
Feature/allow bracketed long delimiters

### DIFF
--- a/StringCalculator/Calculator.cs
+++ b/StringCalculator/Calculator.cs
@@ -48,59 +48,79 @@ namespace StringCalculator
         {
             int startOfNumberString = 0;
             List<string> delimiterList = new List<string>();
+
+            string delimiterPortion = GetDelimiterPortion(numberString);            
+
+            //Add custom delimiters
+            if (!string.IsNullOrEmpty(delimiterPortion)) //has delimiters
+            {
+                string[] customDelimiters = GetCustomDelimiters(delimiterPortion);
+                foreach (string customDelimiter in customDelimiters)
+                {
+                    delimiterList.Add(customDelimiter);
+                }
+                startOfNumberString = delimiterPortion.Length + 3;  //add 3 to account for the // and \n chars
+            }
+            //Add default delimiters
             delimiterList.Add(",");
             delimiterList.Add("\n");
-
-            string[] customDelimiters = GetCustomDelimiters(numberString);
-            foreach (string customDelimiter in customDelimiters)
-            {
-                delimiterList.Add(customDelimiter);
-                startOfNumberString = numberString.IndexOf("\n") + 1;  //used to remove the custom delimiter portion of string
-            }
 
             return numberString.Substring(startOfNumberString).Split(delimiterList.ToArray(), StringSplitOptions.RemoveEmptyEntries);
         }
 
-        public string[] GetCustomDelimiters(string numberString)
+        /// <summary>
+        /// Parses the string to return the portion defining custom delimiters
+        /// </summary>
+        /// <param name="numberString"></param>
+        /// <returns>the portion of the string defining custom delimiters</returns>
+        public string GetDelimiterPortion(string numberString)
         {
             //Use regex to pull just the portion of the string with delimiters
             //This is the area between the opening // and the first \n that is not within a bracket set.
-            string delimiterDefinedPattern = @"^//(\[?.*\]?)\n";
+            string delimiterDefinedPattern = @"^//\[?.*\]?\n";
             Match delimitersFound = Regex.Match(numberString, delimiterDefinedPattern);
 
             if (delimitersFound.Success)
             {
                 int delimiterCharLength = delimitersFound.Value.Length - 3;  //subtract to account for the // and \n in the length
-                string delimiterPortion = delimitersFound.Value.Substring(2, delimiterCharLength);
-
-                //Use second regex to determine if there is a matchig set of open and close brackets
-                //It's a greedy match so will match the longest.  Example:  "[***][&][*\n]"
-                string bracketSectionPattern = @"^(\[.+\])";
-                Match bracketedDelimitersFound = Regex.Match(delimiterPortion, bracketSectionPattern);
-                
-                if (bracketedDelimitersFound.Success)
-                {
-                    List<string> delimiterList = new List<string>();
-                    //Use third regex to break multiple brackets into individual sets of brackets.
-                    //Given string "[***][&][*\n]" it will match [***] first and then move on to next match.
-                    string bracketSetsPattern = @"\[.+?\]";
-                    Match bracketSetsFound = Regex.Match(delimiterPortion, bracketSetsPattern);                    
-                    while (bracketSetsFound.Success)
-                    {
-                        delimiterList.Add(bracketSetsFound.Value.Substring(1, bracketSetsFound.Value.Length - 2)); //remove brackets
-                        bracketSetsFound = bracketSetsFound.NextMatch(); //Get the next bracket set.
-                    }
-                    return delimiterList.ToArray();
-                }
-                else
-                {
-                    //handle non-bracketed (single) delimiter
-                    return new string[] { delimiterPortion };
-                }
+                return delimitersFound.Value.Substring(2, delimiterCharLength);
             }
             else
             {
-                return new string[] {};
+                return "";
+            }
+        }
+
+        /// <summary>
+        /// Parses delimiter string to break up into a string array of delimiters
+        /// </summary>
+        /// <param name="delimiterPortion"></param>
+        /// <returns>a string array with all custom delimiters</returns>
+        public string[] GetCustomDelimiters(string delimiterPortion)
+        {
+            //Use regex to determine if there is a matching set of open and close brackets
+            //It's a greedy match so will match the longest.  Example:  "[***][&][*\n]"
+            string bracketSectionPattern = @"^\[.+\]";
+            Match bracketedDelimitersFound = Regex.Match(delimiterPortion, bracketSectionPattern);
+                
+            if (bracketedDelimitersFound.Success)
+            {
+                List<string> delimiterList = new List<string>();
+                //Use second regex to break multiple brackets into individual sets of brackets.
+                //Given string "[***][&][*\n]" it will match [***] first and then move on to next match.
+                string bracketSetsPattern = @"\[.+?\]";
+                Match bracketSetsFound = Regex.Match(delimiterPortion, bracketSetsPattern);                    
+                while (bracketSetsFound.Success)
+                {
+                    delimiterList.Add(bracketSetsFound.Value.Substring(1, bracketSetsFound.Value.Length - 2)); //remove brackets
+                    bracketSetsFound = bracketSetsFound.NextMatch(); //Get the next bracket set.
+                }
+                return delimiterList.ToArray();
+            }
+            else
+            {
+                //handle non-bracketed (single) delimiter
+                return new string[] { delimiterPortion };
             }
         }
 

--- a/StringCalculator/Calculator.cs
+++ b/StringCalculator/Calculator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Text.RegularExpressions;
 using StringCalculator.Exceptions;
 
 namespace StringCalculator
@@ -47,17 +47,59 @@ namespace StringCalculator
         public string[] ParseNumbers(string numberString)
         {
             int startOfNumberString = 0;
-            string customDelimiter = GetCustomNonBracketedDelimiter(numberString);
             List<string> delimiterList = new List<string>();
             delimiterList.Add(",");
             delimiterList.Add("\n");
-            if (customDelimiter != null)
+
+            string[] customDelimiters = GetCustomDelimiters(numberString);
+            foreach (string customDelimiter in customDelimiters)
             {
                 delimiterList.Add(customDelimiter);
                 startOfNumberString = numberString.IndexOf("\n") + 1;  //used to remove the custom delimiter portion of string
-            }
+            }         
+
+            //string customDelimiter = GetCustomNonBracketedDelimiter(numberString);
+            /*if (customDelimiter != null)
+            {
+                delimiterList.Add(customDelimiter);
+                startOfNumberString = numberString.IndexOf("\n") + 1;  //used to remove the custom delimiter portion of string
+            }*/
 
             return numberString.Substring(startOfNumberString).Split(delimiterList.ToArray(), StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        public string[] GetCustomDelimiters(string numberString)
+        {
+            //use regex to pull just the portion of the string with delimiters
+            //This is the area between the opening // and the first \n
+            string delimiterDefinedPattern = @"^//(\[?.*\]?)\n";
+            Match delimitersFound = Regex.Match(numberString, delimiterDefinedPattern);
+
+            if (delimitersFound.Success)
+            {
+                int delimiterCharLength = delimitersFound.Value.Length - 3;  //subtract 3 to account for the // and \n
+                string delimiterPortion = delimitersFound.Value.Substring(2, delimiterCharLength);
+                                
+                //use second regex to determine if there is a matchig set of open and close brackets
+                string bracketSetPattern = @"^(\[.*\])";
+                Match bracketedDelimitersFound = Regex.Match(delimiterPortion, bracketSetPattern);
+
+                
+                if (bracketedDelimitersFound.Success)
+                {
+                    //todo for now
+                    return new string[] { "todo" };
+                }
+                else
+                {
+                    //handle non-bracketed (single) delimiter
+                    return new string[] { delimiterPortion };
+                }
+            }
+            else
+            {
+                return new string[] {};
+            }
         }
 
         /// <summary>
@@ -69,6 +111,7 @@ namespace StringCalculator
         {
             int endDelimiterMarker = 0;
 
+            //determine if custom delimiters are defined based off the beginning of the string
             if (numberString.Length >= 2 && numberString.Substring(0,2) == "//")
             {
                 endDelimiterMarker = numberString.IndexOf("\n");

--- a/StringCalculator/Calculator.cs
+++ b/StringCalculator/Calculator.cs
@@ -47,7 +47,7 @@ namespace StringCalculator
         public string[] ParseNumbers(string numberString)
         {
             int startOfNumberString = 0;
-            string customDelimiter = GetCustomDelimiter(numberString);
+            string customDelimiter = GetCustomNonBracketedDelimiter(numberString);
             List<string> delimiterList = new List<string>();
             delimiterList.Add(",");
             delimiterList.Add("\n");
@@ -65,7 +65,7 @@ namespace StringCalculator
         /// </summary>
         /// <param name="numberString">String consisting of delimiter information and numbers.</param>
         /// <returns>The custom delimiter if found, otherwise returns null.</returns>
-        public string GetCustomDelimiter(string numberString)
+        public string GetCustomNonBracketedDelimiter(string numberString)
         {
             int endDelimiterMarker = 0;
 

--- a/StringCalculator/Calculator.cs
+++ b/StringCalculator/Calculator.cs
@@ -56,39 +56,41 @@ namespace StringCalculator
             {
                 delimiterList.Add(customDelimiter);
                 startOfNumberString = numberString.IndexOf("\n") + 1;  //used to remove the custom delimiter portion of string
-            }         
-
-            //string customDelimiter = GetCustomNonBracketedDelimiter(numberString);
-            /*if (customDelimiter != null)
-            {
-                delimiterList.Add(customDelimiter);
-                startOfNumberString = numberString.IndexOf("\n") + 1;  //used to remove the custom delimiter portion of string
-            }*/
+            }
 
             return numberString.Substring(startOfNumberString).Split(delimiterList.ToArray(), StringSplitOptions.RemoveEmptyEntries);
         }
 
         public string[] GetCustomDelimiters(string numberString)
         {
-            //use regex to pull just the portion of the string with delimiters
-            //This is the area between the opening // and the first \n
+            //Use regex to pull just the portion of the string with delimiters
+            //This is the area between the opening // and the first \n that is not within a bracket set.
             string delimiterDefinedPattern = @"^//(\[?.*\]?)\n";
             Match delimitersFound = Regex.Match(numberString, delimiterDefinedPattern);
 
             if (delimitersFound.Success)
             {
-                int delimiterCharLength = delimitersFound.Value.Length - 3;  //subtract 3 to account for the // and \n
+                int delimiterCharLength = delimitersFound.Value.Length - 3;  //subtract to account for the // and \n in the length
                 string delimiterPortion = delimitersFound.Value.Substring(2, delimiterCharLength);
-                                
-                //use second regex to determine if there is a matchig set of open and close brackets
-                string bracketSetPattern = @"^(\[.*\])";
-                Match bracketedDelimitersFound = Regex.Match(delimiterPortion, bracketSetPattern);
 
+                //Use second regex to determine if there is a matchig set of open and close brackets
+                //It's a greedy match so will match the longest.  Example:  "[***][&][*\n]"
+                string bracketSectionPattern = @"^(\[.+\])";
+                Match bracketedDelimitersFound = Regex.Match(delimiterPortion, bracketSectionPattern);
                 
                 if (bracketedDelimitersFound.Success)
                 {
-                    //todo for now
-                    return new string[] { "todo" };
+                    List<string> delimiterList = new List<string>();
+                    //Use third regex to break multiple brackets into individual sets of brackets.
+                    //Given string "[***][&][*\n]" it will match [***] first and then move on to next match.
+                    string bracketSetsPattern = @"\[.+?\]";
+                    Match bracketSetsFound = Regex.Match(delimiterPortion, bracketSetsPattern);                    
+                    while (bracketSetsFound.Success)
+                    {
+                        delimiterList.Add(bracketSetsFound.Value.Substring(1, bracketSetsFound.Value.Length - 2)); //remove brackets
+                        bracketSetsFound = bracketSetsFound.NextMatch(); //Get the next bracket set.
+                    }
+                    return delimiterList.ToArray();
                 }
                 else
                 {
@@ -100,27 +102,6 @@ namespace StringCalculator
             {
                 return new string[] {};
             }
-        }
-
-        /// <summary>
-        /// Finds custom delimiter in string array.  Currently only supports one delimiter.
-        /// </summary>
-        /// <param name="numberString">String consisting of delimiter information and numbers.</param>
-        /// <returns>The custom delimiter if found, otherwise returns null.</returns>
-        public string GetCustomNonBracketedDelimiter(string numberString)
-        {
-            int endDelimiterMarker = 0;
-
-            //determine if custom delimiters are defined based off the beginning of the string
-            if (numberString.Length >= 2 && numberString.Substring(0,2) == "//")
-            {
-                endDelimiterMarker = numberString.IndexOf("\n");
-                if (endDelimiterMarker != -1)
-                {
-                    return numberString.Substring(2, endDelimiterMarker - 2);
-                }
-            }
-            return null;
         }
 
         /// <summary>

--- a/StringCalculatorTests/AssignmentFunctionalityTest.cs
+++ b/StringCalculatorTests/AssignmentFunctionalityTest.cs
@@ -152,7 +152,8 @@ namespace StringCalculatorTests
         /// </summary>
         [Theory]
         [InlineData("//[***]\n1***2***3", 6)]
-        [InlineData("//[;]\n2;1001", 2)]        
+        [InlineData("//[;]\n2;1001", 2)]
+        [InlineData("//[&&]\n1&&2,3", 6)]
         public void TestFunctionality7(string numberString, int expected)
         {
             //Act

--- a/StringCalculatorTests/AssignmentFunctionalityTest.cs
+++ b/StringCalculatorTests/AssignmentFunctionalityTest.cs
@@ -145,5 +145,21 @@ namespace StringCalculatorTests
             //Assert
             Assert.Equal(expected, sum);
         }
+
+        /// <summary>
+        /// Tests functionality in requirement 7.
+        /// 7.	Delimiters can be of any length with the following format:  “//[delimiter]\n” for example: “//[***]\n1***2***3” should return 6
+        /// </summary>
+        [Theory]
+        [InlineData("//[***]\n1***2***3", 6)]
+        [InlineData("//[;]\n2;1001", 2)]        
+        public void TestFunctionality7(string numberString, int expected)
+        {
+            //Act
+            int sum = calc.Add(numberString);
+
+            //Assert
+            Assert.Equal(expected, sum);
+        }
     }
 }

--- a/StringCalculatorTests/CalculatorUnitTest.cs
+++ b/StringCalculatorTests/CalculatorUnitTest.cs
@@ -44,7 +44,7 @@ namespace StringCalculatorTests
         public void SumInput_WithEmptyArrayOfNumberStrings_ReturnsSum()
         {
             //Arrange
-            string[] numbers = new string[] {};
+            string[] numbers = new string[] { };
 
             //Act
             int sum = calc.SumInput(numbers);
@@ -130,10 +130,11 @@ namespace StringCalculatorTests
 
         /// <summary>
         /// Tests that a single custom delimiter will separate the numbers into an array of strings
-        /// The Delimiter can be multiple chars long.
+        /// The Delimiter can be multiple chars long.  This is not specifically mentioned in the assignment 
+        /// but I figure include support for a better usabilty.
         /// </summary>
         [Fact]
-        public void ParseNumbers_WithCustomDelimiters_ReturnsStringArrayOfNumbers()
+        public void ParseNumbers_WithCustomNonBracketedDelimiters_ReturnsStringArrayOfNumbers()
         {
             //Act
             string[] set1 = calc.ParseNumbers("//;\n1;2;3");
@@ -153,9 +154,35 @@ namespace StringCalculatorTests
             Assert.Equal("2", set3[1]);
             Assert.Equal("3", set3[2]);
         }
-        
+
         /// <summary>
-        /// Tests retrieval of a single custom delimiter
+        /// Tests that a single custom bracketed delimiter will separate the numbers into an array of strings
+        /// The Delimiter can be multiple chars long.
+        /// </summary>
+        [Fact]
+        public void ParseNumbers_WithCustomBracketedDelimiters_ReturnsStringArrayOfNumbers()
+        {
+            //Act
+            string[] set1 = calc.ParseNumbers("//[;]\n1;2;3");
+            string[] set2 = calc.ParseNumbers("//[&]\n1&2\n3");
+            string[] set3 = calc.ParseNumbers("//[**]\n1**2\n3");
+
+            //Assert
+            Assert.Equal("1", set1[0]);
+            Assert.Equal("2", set1[1]);
+            Assert.Equal("3", set1[2]);
+
+            Assert.Equal("1", set2[0]);
+            Assert.Equal("2", set2[1]);
+            Assert.Equal("3", set2[2]);
+
+            Assert.Equal("1", set3[0]);
+            Assert.Equal("2", set3[1]);
+            Assert.Equal("3", set3[2]);
+        }
+
+        /// <summary>
+        /// Tests retrieval of a single non bracketed custom delimiter
         /// returns null if no custom delimiter is found, otherwise should return one delimiter
         /// </summary>
         /// <param name="numberString"></param>
@@ -163,15 +190,16 @@ namespace StringCalculatorTests
         [Theory]
         [InlineData("//;\n1;2", ";")]
         [InlineData("//;\n1;2\n4", ";")]
-        [InlineData("1,2\n4", null)]  
         public void GetCustomDelimiter_SingleNonBracketedDelimter_ReturnsDelimiter(string numberString, string expected)
         {
             //Act
-            string delimiter = calc.GetCustomNonBracketedDelimiter(numberString);
+            string[] delimiter = calc.GetCustomDelimiters(numberString);
 
             //Assert
-            Assert.Equal(expected, delimiter);
+            Assert.Equal(expected, delimiter[0]);
         }
+
+
 
         /// <summary>
         /// Tests the Add method in general

--- a/StringCalculatorTests/CalculatorUnitTest.cs
+++ b/StringCalculatorTests/CalculatorUnitTest.cs
@@ -183,23 +183,38 @@ namespace StringCalculatorTests
 
         /// <summary>
         /// Tests retrieval of a single non bracketed custom delimiter
-        /// returns null if no custom delimiter is found, otherwise should return one delimiter
         /// </summary>
-        /// <param name="numberString"></param>
+        /// <param name="delimiterPortion"></param>
         /// <param name="expected"></param>
         [Theory]
-        [InlineData("//;\n1;2", ";")]
-        [InlineData("//;\n1;2\n4", ";")]
-        public void GetCustomDelimiter_SingleNonBracketedDelimter_ReturnsDelimiter(string numberString, string expected)
+        [InlineData(";", ";")]
+        [InlineData("&", "&")]
+        public void GetCustomDelimiter_SingleNonBracketedDelimter_ReturnsDelimiter(string delimiterPortion, string expected)
         {
             //Act
-            string[] delimiter = calc.GetCustomDelimiters(numberString);
+            string[] delimiter = calc.GetCustomDelimiters(delimiterPortion);
 
             //Assert
             Assert.Equal(expected, delimiter[0]);
         }
 
+        /// <summary>
+        /// Tests retrieval of a single bracketed custom delimiter
+        /// </summary>
+        /// <param name="delimiterPortion"></param>
+        /// <param name="expected"></param>
+        [Theory]
+        [InlineData("[;]", ";")]
+        [InlineData("[&]", "&")]
+        [InlineData("[&&]", "&&")]
+        public void GetCustomDelimiter_BracketedDelimter_ReturnsDelimiter(string delimiterPortion, string expected)
+        {
+            //Act
+            string[] delimiter = calc.GetCustomDelimiters(delimiterPortion);
 
+            //Assert
+            Assert.Equal(expected, delimiter[0]);
+        }
 
         /// <summary>
         /// Tests the Add method in general

--- a/StringCalculatorTests/CalculatorUnitTest.cs
+++ b/StringCalculatorTests/CalculatorUnitTest.cs
@@ -164,10 +164,10 @@ namespace StringCalculatorTests
         [InlineData("//;\n1;2", ";")]
         [InlineData("//;\n1;2\n4", ";")]
         [InlineData("1,2\n4", null)]  
-        public void GetCustomDelimiter_SingleDelimter_ReturnsDelimiter(string numberString, string expected)
+        public void GetCustomDelimiter_SingleNonBracketedDelimter_ReturnsDelimiter(string numberString, string expected)
         {
             //Act
-            string delimiter = calc.GetCustomDelimiter(numberString);
+            string delimiter = calc.GetCustomNonBracketedDelimiter(numberString);
 
             //Assert
             Assert.Equal(expected, delimiter);


### PR DESCRIPTION
Implemented require 7 that allows for multi-char delimiters defined within brackets.
7.	Delimiters can be of any length with the following format:  “//[delimiter]\n” for example: “//[***]\n1***2***3” should return 6