### PR TITLE
Implements requirement 8, the ability to have multiple single bracket…

### DIFF
--- a/StringCalculatorTests/AssignmentFunctionalityTest.cs
+++ b/StringCalculatorTests/AssignmentFunctionalityTest.cs
@@ -162,5 +162,22 @@ namespace StringCalculatorTests
             //Assert
             Assert.Equal(expected, sum);
         }
+
+        /// <summary>
+        /// Tests functionality in requirement 8.
+        /// 8.	Allow multiple delimiters like this:  “//[delim1][delim2]\n” for example “//[*][%]\n1*2%3” should return 6.
+        /// </summary>
+        [Theory]
+        [InlineData("//[*][&]\n1*2&3", 6)]
+        [InlineData("//[;]\n2;1001", 2)]
+        [InlineData("//[&][*][;]\n1&2;3*3", 9)]
+        public void TestFunctionality8(string numberString, int expected)
+        {
+            //Act
+            int sum = calc.Add(numberString);
+
+            //Assert
+            Assert.Equal(expected, sum);
+        }
     }
 }

--- a/StringCalculatorTests/CalculatorUnitTest.cs
+++ b/StringCalculatorTests/CalculatorUnitTest.cs
@@ -182,6 +182,25 @@ namespace StringCalculatorTests
         }
 
         /// <summary>
+        /// Tests that GetDelimiterPortion returns only the section defining the delimiters
+        /// </summary>
+        /// <param name="numberString"></param>
+        /// <param name="expected">The portion of the string defining the delimiters.</param>
+        [Theory]
+        [InlineData("//&\n1,2&3", "&")]
+        [InlineData("//[&]\n1,2&3", "[&]")]
+        [InlineData("//[&][*]\n1,2&3,*4", "[&][*]")]
+        [InlineData("//[&&&][**]\n1**2&&&3", "[&&&][**]")]
+        public void GetDelimiterPortion_WithCustomBracketedDelimiters_ReturnDelimiterString(string numberString, string expected)
+        {
+            //Act
+            string delimiterPortion = calc.GetDelimiterPortion(numberString);
+
+            //Assert
+            Assert.Equal(expected, delimiterPortion);
+        }
+
+        /// <summary>
         /// Tests retrieval of a single non bracketed custom delimiter
         /// </summary>
         /// <param name="delimiterPortion"></param>


### PR DESCRIPTION
…ed delimiters

8.	Allow multiple delimiters like this:  “//[delim1][delim2]\n” for example “//[*][%]\n1*2%3” should return 6.
No additional code changes to Calculator.cs were needed to implement this.  Just added testing for it.